### PR TITLE
Image added php:7.4-fpm for compatibility with Magento versions >= 2.4

### DIFF
--- a/config/dockergento/nginx/conf/default.conf
+++ b/config/dockergento/nginx/conf/default.conf
@@ -176,6 +176,7 @@ server {
     try_files $uri =404;
     fastcgi_pass   $my_fastcgi_pass:9000;
     fastcgi_buffers 1024 4k;
+    fastcgi_buffer_size 32k;
 
     fastcgi_param  PHP_FLAG  "session.auto_start=off \n suhosin.session.cryptua=off";
     fastcgi_param  PHP_VALUE "memory_limit=768M \n max_execution_time=600";

--- a/console/commands/setup.sh
+++ b/console/commands/setup.sh
@@ -141,7 +141,7 @@ fi
 
 echo "PHP version:"
 DEFAULT_PHP_VERSION="7.1"
-AVAILABLE_PHP_VERSIONS="7.0 7.1 7.2 7.3"
+AVAILABLE_PHP_VERSIONS="7.0 7.1 7.2 7.3 7.4"
 select PHP_VERSION in ${AVAILABLE_PHP_VERSIONS}; do
     if $(${TASKS_DIR}/in_list.sh "${PHP_VERSION}" "${AVAILABLE_PHP_VERSIONS}"); then
         break


### PR DESCRIPTION
Increased fastcgi_buffer_size to 32K. 
This will fix Magento 2.4 max buffer size error.